### PR TITLE
AMQP tracestate should be string

### DIFF
--- a/spec/20-AMQP_FORMAT.md
+++ b/spec/20-AMQP_FORMAT.md
@@ -49,7 +49,7 @@ there anything in AMQP protocol that can be used to carry this context?
 ## `traceparent` AMQP format
 
 The field `traceparent` MUST be encoded and decoded using [binary
-protocol](..\extension-binary.html) and stored as a binary type defined in
+protocol](https://w3c.github.io/trace-context-binary/) and stored as a binary type defined in
 section
 [1.6.19](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-binary)
 of AMQP specification.
@@ -58,10 +58,12 @@ Property name MUST be `traceparent` - all lowercase without delimiters.
 
 ## `tracestate` AMQP format
 
-The field `tracestate` MUST be encoded and decoded as a string to string map.
-See definition of type map in section
-[1.6.23](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-map)
+The field `tracestate` MUST be encoded and decoded as a string.
+See definition of string in section
+[1.6.20](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-string)
 of AMQP specification.
+
+`tracestate` field MUST be encoded according to [HTTP Trace Context spec](https://www.w3.org/TR/trace-context/#tracestate-field), however multiple properties with `tracestate` are not permitted. 
 
 ---
 

--- a/spec/21-AMQP_FORMAT_RATIONALE.md
+++ b/spec/21-AMQP_FORMAT_RATIONALE.md
@@ -13,21 +13,18 @@ protocol. So using them is fully supported by all existing clients.
 ## Binary `traceparent` vs. list of binary values
 
 There are multiple ways to implement a `traceparent`. It can either be
-implemented as string (http-like), binary protocol (like for grpc) or list of
-separate binary values (`trace-id`, `parent-id`, `trace-flags`).
+implemented as string (http-like), binary protocol or list of separate 
+binary values (`trace-id`, `parent-id`, `trace-flags`).
 
 Strings duplicating the size of a field, using list of binaries will require to
 redefine the way the field serialized, parsed, and versioned. So re-using binary
 protocol looks like a logical solution.
 
-## AMQP map for `tracestate`
+## AMQP string for `tracestate`
 
-The benefit of using a built-in map type for AMQP is that serialization and
-de-serialization of the field is built in and doesn't require any custom
-implementation for parsing it.
-
-Maps in AMQP preserving the order so there is no conflict with the semantics of
-the field.
+The benefit of using a string http-like encoding for AMQP is that no serialization/de-serialization 
+is required for blind propagation and interoperability with HTTP version of the protocol 
+in broker services (HTTP-over-AMQP and vice versa scenarios) or user applications. 
 
 ## Why use both - application and message properties
 


### PR DESCRIPTION
Consider changing tracestate to be encoded as string

**Pros**:
- AMQP libraries do not need to implement complex logic of parsing/serializing tracestate
- Same as prev: blind propagation must be extremely efficient and simple. User applications that use AMQP  also likely use HTTP. If they never change tracestate - there is no need to serialize it back and forth. 
- There are no bandwidth improvements coming from map usage
- On the implementation layer, using maps is not efficient: ordered dictionaries are not very efficient especially for a handful of items
- if tracestate parsing is controlled by tracing system, at least it can mitigate some of the perf impact  parsing tracestate only on sampled in spans.

**Cons**:
- Tracing systems need to parse tracestate from string (needless to say, it already has to because of HTTP)

Overall tracestate is tracing system concern and it seems practical to save protocol implementations from dealing with tracestate specifics.